### PR TITLE
enable imagemagick option

### DIFF
--- a/connectors/php/commands.php
+++ b/connectors/php/commands.php
@@ -474,6 +474,15 @@ function filemanager_getthumbname($path) {
 	return str_replace('/', '_-_', $path);
 }
 function filemanager_imagemagick_check() {
+  global $Config;
+	if (isset($Config['ThumbEnableImagemagick'])) {
+		return (bool)$Config['ThumbEnableImagemagick'];
+	} else {
+		if (strtoupper(substr(PHP_OS,0,3)) === 'WIN') {
+			// don't run convert on windows unless 'imagemagick' is in path
+      if (strpos(strtolower(getenv('PATH')),'imagemagick') === false) return false;
+		}
+	}
 	return strpos(`convert -version`, 'ImageMagick') !== false ? true : false;
 }
 function filemanager_gd2_check() {

--- a/connectors/php/config.php
+++ b/connectors/php/config.php
@@ -21,6 +21,7 @@ $Config['ThumbCreate'] = true;  // При закачке можно изменя
 $Config['ThumbList'] = true;    // Показывать превьюшки
 $Config['ThumbListSize'] = 100; // Размер превьюшки, вписывается в квадрат
 $Config['ThumbMaxGenerate'] = 5; // Максимальное количество превьюшек, генерируемое за раз, если вдруг их нет
+$Config['ThumbEnableImagemagick'] = null; // Использовать imagemagick (null = использовать, если удастся обнаружить)
 
 // Path to user files relative to the document root.
 $Config['UserFilesPath'] = '/data/ckfsys2/files/' ;


### PR DESCRIPTION
Если под windows запускать convert, при неустановленном imagemagick, то в error.log пишется "Неправильно указан диск."

filemanager_imagemagick_check() смотрит, есть ли каталог imagemagick в path, прежде чем запускать convert, а на случай, если imagemagick установлен как-то иначе, добавлена опция, чтобы проверку не делать.
